### PR TITLE
fix(zabbix_monitoring): Remove directory creation task

### DIFF
--- a/roles/zabbix_monitoring/tasks/main.yml
+++ b/roles/zabbix_monitoring/tasks/main.yml
@@ -1,11 +1,9 @@
 ---
-- name: Create directory for rootless podman socket which is accessible by Zabbix user
-  ansible.builtin.file:
-    path: "/var/run/{{ zabbix_monitoring_podman_user }}"
-    state: directory
-    owner: "{{ zabbix_monitoring_podman_user }}"
-    group: "{{ zabbix_monitoring_zabbix_group }}"
-    mode: '0755'
+- name: Add Zabbix user to podman group
+  ansible.builtin.user:
+    name: "{{ zabbix_monitoring_zabbix_user }}"
+    groups: "{{ zabbix_monitoring_podman_user }}"
+    append: true
 
 - name: Get podman user info
   ansible.builtin.getent:
@@ -29,9 +27,8 @@
         content: |
           [Socket]
           ListenStream=
-          ListenStream=/var/run/{{ zabbix_monitoring_podman_user }}/podman.sock
-          SocketMode=
-          SocketMode=0666
+          ListenStream=/tmp/{{ zabbix_monitoring_podman_user }}/podman/podman.sock
+          DirectoryMode=0750
         mode: '0644'
 
     - name: Reload systemd and enable podman.socket unit
@@ -50,7 +47,7 @@
 - name: Configure Zabbix agent to monitor rootless podman containers
   ansible.builtin.lineinfile:
     path: "/etc/zabbix/zabbix_agent2.d/plugins.d/docker.conf"
-    line: "Plugins.Docker.Endpoint=unix:///var/run/{{ zabbix_monitoring_podman_user }}/podman.sock"
+    line: "Plugins.Docker.Endpoint=unix:///tmp/{{ zabbix_monitoring_podman_user }}/podman/podman.sock"
     insertafter: EOF
 
 - name: Restart Zabbix agent


### PR DESCRIPTION
There was a mistake with the created directory in `/var/run/`. It's not surprisingly deleted during a reboot. Therefore the configuration of systemd socket was adjusted to create socket in `/tmp/` and the directories will get created on socket start if they don't exist and permission set to `0750`. This requires the monitoring user to be a member of the group of the user running the rootless podman.